### PR TITLE
Add reviews and subjects endpoints

### DIFF
--- a/assignments.go
+++ b/assignments.go
@@ -6,8 +6,8 @@ import (
 )
 
 type Assignment struct {
-	Type          string    `json:"subject_type"`
-	Id            int       `json:"subject_id"`
+	SubjectType   string    `json:"subject_type"`
+	SubjectId     int       `json:"subject_id"`
 	Level         int       `json:"level"`
 	Stage         int       `json:"srs_stage"`
 	UnlockedAt    time.Time `json:"unlocked_at"`
@@ -32,73 +32,63 @@ func WithAvailableBefore(t time.Time) Option {
 	}
 }
 
-func WithBurned() Option {
+func WithBurned(burned bool) Option {
 	return func(cfg *options) error {
-		cfg.params["burned"] = append(cfg.params["burned"], "true")
+		cfg.params["burned"] = []string{strconv.FormatBool(burned)}
 		return nil
 	}
 }
 
-func WithHidden() Option {
+func WithAvailableLessons(available bool) Option {
 	return func(cfg *options) error {
-		cfg.params["hidden"] = append(cfg.params["hidden"], "true")
+		cfg.params["available_lessons"] = []string{strconv.FormatBool(available)}
 		return nil
 	}
 }
 
-func WithAvailableLessons() Option {
+func WithAvailableReviews(available bool) Option {
 	return func(cfg *options) error {
-		cfg.params["available_lessons"] = append(cfg.params["available_lessons"], "true")
-		return nil
-	}
-}
-
-func WithAvailableReviews() Option {
-	return func(cfg *options) error {
-		cfg.params["available_reviews"] = append(cfg.params["available_reviews"], "true")
-		return nil
-	}
-}
-
-func WithLevels(levels []int) Option {
-	return func(cfg *options) error {
-		for _, level := range levels {
-			cfg.params["levels"] = append(cfg.params["levels"], strconv.Itoa(level))
-		}
+		cfg.params["available_reviews"] = []string{strconv.FormatBool(available)}
 		return nil
 	}
 }
 
 func WithStage(stages []int) Option {
 	return func(cfg *options) error {
-		for _, s := range stages {
-			cfg.params["srs_stages"] = append(cfg.params["srs_stages"], strconv.Itoa(s))
+		strStages := make([]string, len(stages))
+		for i, s := range stages {
+			strStages[i] = strconv.Itoa(s)
 		}
+		cfg.params["srs_stages"] = strStages
 		return nil
 	}
 }
 
 func WithSubjectIDs(ids []int) Option {
 	return func(cfg *options) error {
-		for _, id := range ids {
-			cfg.params["subject_ids"] = append(cfg.params["subject_ids"], strconv.Itoa(id))
+		strId := make([]string, len(ids))
+		for i, id := range ids {
+			strId[i] = strconv.Itoa(id)
 		}
+		cfg.params["subject_ids"] = strId
 		return nil
 	}
 }
 
 func WithSubjectTypes(types []string) Option {
 	return func(cfg *options) error {
-		for _, t := range types {
-			cfg.params["subject_types"] = append(cfg.params["subject_types"], t)
+		strTypes := make([]string, len(types))
+		for i, t := range types {
+			strTypes[i] = t
 		}
+		cfg.params["subject_types"] = strTypes
 		return nil
 	}
 }
 
-func WithUnlocked() Option {
+func WithUnlocked(unlocked bool) Option {
 	return func(cfg *options) error {
-		cfg.params["unlocked"] = append(cfg.params["unlocked"], "true")
+		cfg.params["unlocked"] = []string{strconv.FormatBool(unlocked)}
 		return nil
 	}
 }

--- a/config.go
+++ b/config.go
@@ -13,16 +13,18 @@ type Option func(*options) error
 
 func WithIds(ids []int) Option {
 	return func(cfg *options) error {
-		for _, id := range ids {
-			cfg.params["ids"] = append(cfg.params["ids"], strconv.Itoa(id))
+		strId := make([]string, len(ids))
+		for i, id := range ids {
+			strId[i] = strconv.Itoa(id)
 		}
+		cfg.params["ids"] = strId
 		return nil
 	}
 }
 
 func WithUpdatedAfter(t time.Time) Option {
 	return func(cfg *options) error {
-		cfg.params["updated_after"] = append(cfg.params["updated_after"], t.Format(time.RFC3339))
+		cfg.params["updated_after"] = []string{t.Format(time.RFC3339)}
 		return nil
 	}
 }

--- a/payloads.go
+++ b/payloads.go
@@ -7,15 +7,10 @@ type Assignments struct {
 }
 
 type Reviews struct {
-	Reviews struct {
-		AssignmentId      int       `json:"assignment_id"`
-		IncorrectMeanings int       `json:"incorrect_meaning_answers"`
-		IncorrectReadings int       `json:"incorrect_reading_answers"`
-		CreatedAt         time.Time `json:"created_at"`
-	} `json:"reviews"`
+	Review ReviewBase `json:"review"`
 }
 
-type StudyMaterial struct {
+type StudyMaterials struct {
 	StudyMaterial struct {
 		SubjectId       int      `json:"subject_id"`
 		MeaningNote     string   `json:"meaning_note"`
@@ -24,7 +19,7 @@ type StudyMaterial struct {
 	} `json:"study_material"`
 }
 
-type User struct {
+type Users struct {
 	User struct {
 		Preferences struct {
 			LessonsAutoplayAudio       bool   `json:"lessons_autoplay_audio"`

--- a/reviews.go
+++ b/reviews.go
@@ -1,0 +1,29 @@
+package wk
+
+import (
+	"strconv"
+	"time"
+)
+
+type ReviewBase struct {
+	AssignmentId      int       `json:"assignment_id"`
+	IncorrectMeanings int       `json:"incorrect_meaning_answers"`
+	IncorrectReadings int       `json:"incorrect_reading_answers"`
+	CreatedAt         time.Time `json:"created_at"`
+}
+
+type Review struct {
+	ReviewBase
+	SubjectId   int `json:"subject_id"`
+	StartingSRS int `json:"starting_srs_stage"`
+	EndingSRS   int `json:"ending_srs_stage"`
+	SRSId       int `json:"spaced_repetition_system_id"`
+}
+
+func (c *Client) GetReview(id int, opts ...Option) (*Resource[Review], error) {
+	return resource[Review](c, "reviews/"+strconv.Itoa(id), "GET", nil, opts...)
+}
+
+func (c *Client) CreateReview(payload Reviews, opts ...Option) (*Resource[Review], error) {
+	return resource[Review](c, "reviews/", "POST", payload, opts...)
+}

--- a/subjects.go
+++ b/subjects.go
@@ -1,0 +1,66 @@
+package wk
+
+import (
+	"strconv"
+	"time"
+)
+
+type Subject struct {
+	AuxiliaryMeanings []struct {
+		Meaning        string `json:"meaning"`
+		Primary        bool   `json:"primary"`
+		AcceptedAnswer bool   `json:"accepted_answer"`
+	}
+	Characters      string    `json:"characters"`
+	CreatedAt       time.Time `json:"created_at"`
+	DocumentURL     string    `json:"document_url"`
+	HiddenAt        time.Time `json:"hidden_at"`
+	Level           int       `json:"level"`
+	MeaningMnemonic string    `json:"meaning_mnemonic"`
+	Meanings        []struct {
+		Meaning string `json:"meaning"`
+		Type    string `json:"type"`
+	}
+	Slug  string `json:"slug"`
+	SRSId int    `json:"spaced_repetition_system_id"`
+}
+
+func WithTypes(types []string) Option {
+	return func(cfg *options) error {
+		cfg.params["types"] = types
+		return nil
+	}
+}
+
+func WithSlugs(slugs []string) Option {
+	return func(cfg *options) error {
+		cfg.params["slugs"] = slugs
+		return nil
+	}
+}
+
+func WithLevels(levels []int) Option {
+	return func(cfg *options) error {
+		strLevels := make([]string, len(levels))
+		for i, l := range levels {
+			strLevels[i] = strconv.Itoa(l)
+		}
+		cfg.params["levels"] = strLevels
+		return nil
+	}
+}
+
+func WithHidden(hidden bool) Option {
+	return func(cfg *options) error {
+		cfg.params["hidden"] = []string{strconv.FormatBool(hidden)}
+		return nil
+	}
+}
+
+func (c *Client) GetSubjects(opts ...Option) (*Paginate[Subject], error) {
+	return paginate[Subject](c, "subjects", opts...)
+}
+
+func (c *Client) GetSubject(id int, opts ...Option) (*Resource[Subject], error) {
+	return resource[Subject](c, "subjects/"+strconv.Itoa(id), "GET", nil, opts...)
+}


### PR DESCRIPTION
### Synopsis
This adds the `reviews` and `subjects` endpoints available through the WK API. This also comes with minor changes to options.

### Reasoning
More coverage of the API in an API client is always nice.